### PR TITLE
Lock version number because new updates to babylonjs and typescript c…

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,12 +12,12 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "babylonjs": "^3.1.1"
+    "babylonjs": "3.1.1"
   },
   "devDependencies": {
-    "typescript": "^2.6.2",
-    "electron-builder": "^19.49.0",
-    "electron": "^1.7.9"
+    "typescript": "2.6.2",
+    "electron-builder": "19.49.0",
+    "electron": "1.7.9"
   },
   "build": {
     "appId": "yourappid",
@@ -35,8 +35,8 @@
         }
       ]
     },
-    "win" : {
-        "target": "portable"
+    "win": {
+      "target": "portable"
     }
   }
 }


### PR DESCRIPTION
…auses build errors.